### PR TITLE
Update task_id parsing to handle new task arn format

### DIFF
--- a/app/sentinel.py
+++ b/app/sentinel.py
@@ -31,7 +31,7 @@ def main():
         r = requests.get(settings.ECS_TASK_STRATEGY_ENDPOINT)
         metadata = r.json()
         logger.debug("metadata was: " + json.dumps(metadata))
-        task_id = metadata["Labels"]["com.amazonaws.ecs.task-arn"].split("/")[1]
+        task_id = metadata["Labels"]["com.amazonaws.ecs.task-arn"].split("/")[-1]
         logger.debug("task_id: " + task_id)
         semaphore_file = settings.ECS_TASK_STRATEGY_SEMAPHORE_FILE_TEMPLATE.replace("##task_id##", task_id)
         logger.info("semaphore file set to " + semaphore_file)


### PR DESCRIPTION
Update how task_id determined as new arn formats are being rolled out. Previously took 2nd element but changed to take last after split. From https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-account-settings.html:

```
Old: arn:aws:ecs:region:aws_account_id:task/task-id

New: arn:aws:ecs:region:aws_account_id:task/cluster-name/task-id
```